### PR TITLE
Adds sniffing and various other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bountiful.useFreeKill         | false             | Whether or not to kill the b
 bountiful.maxBanishCost       | autoBuyPriceLimit | Maximum price willing to spend on individual banishers
 bountiful.maxSpecialCost      | autoBuyPriceLimit | Maximum price willing to spend on special bounty content unlockers
 bountiful.automaticallyGiveup | false             | Whether or not to "Give up" bounties which cannot be accessed
-bountiful.useAllOlfactCharges | false             | Whether or not to use all 3 olfaction charges. Uses up to 2 when false 
+bountiful.useAllOlfactCharges | false             | If false, reserves 1 olfact charge for the user to use later in their KOL day 	(for farming or in-run use). If true, uses all 3 of your daily olfactions on bounty hunting. Note that if you have olfaction, this script will always use up to 2 charges regardless.
 
 To set a property, simply type the following into the gCLI:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ bountiful.useFreeKill         | false             | Whether or not to kill the b
 bountiful.maxBanishCost       | autoBuyPriceLimit | Maximum price willing to spend on individual banishers
 bountiful.maxSpecialCost      | autoBuyPriceLimit | Maximum price willing to spend on special bounty content unlockers
 bountiful.automaticallyGiveup | false             | Whether or not to "Give up" bounties which cannot be accessed
+bountiful.useAllOlfactCharges | false             | Whether or not to use all 3 olfaction charges. Uses up to 2 when false 
 
 To set a property, simply type the following into the gCLI:
 

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,1 +1,0 @@
-https://svn.code.sf.net/p/therazekolmafia/canadv/code/

--- a/scripts/bountiful.ash
+++ b/scripts/bountiful.ash
@@ -73,7 +73,8 @@ int[item] BAN_ITEMS = {
 // TODO: add other skills (mostly IOTMs I don't have)
 boolean[skill] BAN_SKILLS = {
   $skill[Snokebomb] : true,           // Snojo
-  $skill[Talk About Politics] : true  // Pantsgiving
+  $skill[Talk About Politics] : true,  // Pantsgiving
+  $skill[Bowl a Curveball] : true
 };
 
 // Unlockers
@@ -392,7 +393,7 @@ bounty optimal_bounty() {
 */
 boolean hunt_bounty(bounty b) {
   accept_bounty(b.type); // doesn't do anything if already accepted
-  print("There are " + _remaining(optimal_bounty().type).to_string() + " " +
+  print("There are " + _remaining(b.type).to_string() + " " +
         b.plural + " remaining!", "green");
   current = b;
 
@@ -539,6 +540,14 @@ string combat(int round, monster opp, string text) {
   // Check if the current monster is hunted
   if(is_hunted(opp)) {
     print("Hey it's the bounty monster!", "blue");
+
+    // olfact if haven't already for bounty monster. Save 1 olfact for farming purposes
+    monster olfactedMonster = get_property("olfactedMonster").to_monster();
+    if(olfactedMonster != opp && get_property("_olfactionsUsed").to_int() < 2)
+    {
+      print("Sniffing this one!", "blue");
+      return "skill Transcendent Olfaction";
+    }
     // Copy at the beginning of the fight if possible
     // TODO: Fix my_location() not working with copies (putty, etc)
     if(useCopier && (round == 0) && (_remaining(current) > 1)) {
@@ -600,8 +609,9 @@ string combat(int round, monster opp, string text) {
     }
   }
 
+  print("Simply attacking");
   // Default to CCS if custom actions can't/don't need to happen
-  return get_ccs_action(round);
+  return "attack";
 }
 
 //----------------------------------------

--- a/scripts/bountiful.ash
+++ b/scripts/bountiful.ash
@@ -304,7 +304,7 @@ string addBountyToQueue(monster opp, boolean speculate) {
   // Transcendent Olfaction. Save 1 olfact for farming purposes, depending on pref
   int olfactsToUse = useAllOlfactCharges ? 3 : 2;
   monster olfactedMonster = get_property("olfactedMonster").to_monster();
-  if(olfactedMonster != opp && get_property("_olfactionsUsed").to_int() < olfactsToUse)
+  if(olfactedMonster != opp && have_skill($skill[Transcendent Olfaction]) && get_property("_olfactionsUsed").to_int() < olfactsToUse)
   {
     if(!speculate) print("Sniffing this one!", "blue");
     return "skill Transcendent Olfaction";


### PR DESCRIPTION
- Will use the following to add copies of the bounty to the queue (if can survive a few rounds of damage)
  - Transcendent Olfaction. By default, only uses up to two times by default. Saves final charge for whatever else you would like to do that day. Added pref to give option to use all 3 charges
  - Gallapagosian Mating Call
  - Get a Good Whiff of This Guy (From Nosy Nose)
- Fixed skill banishing
- Added banish Bowl a Curveball
- Removed reliance on using the active CCS to kill monsters. Instead, simply attack. Likely will have to flesh this out a bit more in the future.
- Removed can_adv dependency