### PR TITLE
Quark's fixes

### DIFF
--- a/scripts/bountiful.ash
+++ b/scripts/bountiful.ash
@@ -611,7 +611,7 @@ boolean hunt_bounty(bounty b) {
     if(!can_adventure(b.location))
       abort("Couldn't prepare the zone for some reason");
 
-    adventure(1, b.location, "combat");
+    adv1(b.location, "combat");
   } else {
     // turns out we're doing nothing
     print("Can't access bounty location: " + b.location, "orange");
@@ -755,43 +755,47 @@ string combat(int round, monster opp, string text) {
               get_property("_powerPillUses").to_int() < 20) {
       return "item power pill";
     }
+  } else {
+
     // Ban logic
-  } else if(useBan && can_banish(my_location())) {
-    // Prefer skill banishes over items (they're free)
-    skill skill_banisher = get_unused_skill_banisher(my_location());
-    if(skill_banisher != $skill[none]) {
-      print("Going to banish with skill " + skill_banisher.to_string());
-      return "skill " + to_string(skill_banisher);
+    if(useBan && can_banish(my_location()) && !($monsters[blackberry bush,screambat,Smut orc pervert] contains opp)) {
+      // Prefer skill banishes over items (they're free)
+      skill skill_banisher = get_unused_skill_banisher(my_location());
+      if(skill_banisher != $skill[none]) {
+        print("Going to banish with skill " + skill_banisher.to_string());
+        return "skill " + to_string(skill_banisher);
+      }
+
+      item item_banisher = get_unused_item_banisher(my_location());
+
+      // This should never happen but Mafia seems to occasionally not keep track
+      // of banishes for some reason - TODO: Figure this out
+      // BUG: This debugging code introduces a bug...
+      /*
+      if(LAST_BANISH == item_banisher && LAST_LOCATION == my_location()) {
+        abort("Script picked the same banisher (" + LAST_BANISH.to_string() +
+              ") twice in a row for the same location (" + LAST_LOCATION.to_string() + ")");
+      }
+      */
+
+      if(item_amount(item_banisher) > 0) {
+        // For debugging: see above comment
+        LAST_BANISH = item_banisher;
+        LAST_LOCATION = my_location();
+
+        return "item " + to_string(item_banisher);
+      }
     }
+    if(useRun) {
+      // Use familiar run away
+      if(my_familiar() == $familiar[Pair of Stomping Boots] ||
+        (my_familiar() == $familiar[Frumious Bandersnatch] &&
+          have_effect($effect[Ode to Booze]) > 0)) {
 
-    item item_banisher = get_unused_item_banisher(my_location());
-
-    // This should never happen but Mafia seems to occasionally not keep track
-    // of banishes for some reason - TODO: Figure this out
-    // BUG: This debugging code introduces a bug...
-    /*
-    if(LAST_BANISH == item_banisher && LAST_LOCATION == my_location()) {
-      abort("Script picked the same banisher (" + LAST_BANISH.to_string() +
-            ") twice in a row for the same location (" + LAST_LOCATION.to_string() + ")");
-    }
-    */
-
-    if(item_amount(item_banisher) > 0) {
-      // For debugging: see above comment
-      LAST_BANISH = item_banisher;
-      LAST_LOCATION = my_location();
-
-      return "item " + to_string(item_banisher);
-    }
-  } else if(useRun) {
-    // Use familiar run away
-    if(my_familiar() == $familiar[Pair of Stomping Boots] ||
-       (my_familiar() == $familiar[Frumious Bandersnatch] &&
-        have_effect($effect[Ode to Booze]) > 0)) {
-
-      // Yucky nested if statement
-      if(get_property("_banderRunaways").to_int() < round(numeric_modifier("Familiar Weight")) / 5) {
-        return "run away";
+        // Yucky nested if statement
+        if(get_property("_banderRunaways").to_int() < round(numeric_modifier("Familiar Weight")) / 5) {
+          return "run away";
+        }
       }
     }
   }


### PR DESCRIPTION
Duplicate of https://github.com/Alium58/bountiful/pull/1

small fixes that were tested with the original version of the script but not with this fork, but it seems like they should still work

don't try to banish unbanishable monsters
change adv(1) to adv1() to not use one more adv if bounty finished with a free fight like carnivorous potted plant
make ban logic compatible with run awaymonsters to ban and run away from are the same and ban was blocking run away